### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~7.3.0||~7.4.0",
-        "magento/framework": ">=103.0.0",
+        "magento/framework": "^102.0",
         "magento/magento-composer-installer": "*"
     },
     "replace": {


### PR DESCRIPTION
The  Magento 2.3.5 is having magento/framework version: 102,
so we need to change the module requirement to allow the 1.0.2 above.