### PR TITLE
Performance fixes

### DIFF
--- a/AbandonedCart/Block/System/Config/SyncAbandonedCartData.php
+++ b/AbandonedCart/Block/System/Config/SyncAbandonedCartData.php
@@ -3,6 +3,7 @@
  * Copyright © Wagento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace ActiveCampaign\AbandonedCart\Block\System\Config;
 
@@ -15,16 +16,24 @@ use ActiveCampaign\AbandonedCart\Model\Config\CronConfig;
 
 class SyncAbandonedCartData extends Field
 {
-    const AC_SYNC_STATUS = "ac_sync_status";
+    public const AC_SYNC_STATUS = 'ac_sync_status';
+
     /**
      * @var string
      */
     protected $_template = 'ActiveCampaign_AbandonedCart::system/config/sync_abandoned_cart_data.phtml';
 
     /**
+     * @var QuoteResourceCollectionFactory
+     */
+    protected $quoteResourceCollectionFactory;
+
+    /**
+     * Construct
+     *
      * @param Context $context
-     * @param array $data
      * @param QuoteResourceCollectionFactory $quoteResourceCollectionFactory
+     * @param array $data
      */
     public function __construct(
         Context $context,
@@ -37,6 +46,7 @@ class SyncAbandonedCartData extends Field
 
     /**
      * Remove scope label
+     *
      * @param AbstractElement $element
      * @return string
      */
@@ -48,6 +58,7 @@ class SyncAbandonedCartData extends Field
 
     /**
      * Return element html
+     *
      * @param AbstractElement $element
      * @return string
      */
@@ -58,6 +69,7 @@ class SyncAbandonedCartData extends Field
 
     /**
      * Return ajax url for field sync button
+     *
      * @return string
      */
     public function getAjaxUrl()
@@ -67,93 +79,109 @@ class SyncAbandonedCartData extends Field
 
     /**
      * Generate field sync button html
+     *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getButtonHtml()
     {
         $button = $this->getLayout()->createBlock(
             Button::class
         )->setData([
-            'id' => 'ac_sync_abandoned_cart_button',
+            'id'    => 'ac_sync_abandoned_cart_button',
             'label' => __('Sync Abandoned Cart Data'),
         ]);
+
         return $button->toHtml();
     }
 
     /**
-     * @return $this
+     * Get abandoned cart collection
+     *
+     * @return \Magento\Quote\Model\ResourceModel\Quote\Collection
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getAbandonedCartCollection()
     {
-        $collection = $this->quoteResourceCollectionFactory->create()
+        return $this->quoteResourceCollectionFactory->create()
             ->addFieldToSelect('*')
             ->addFieldToFilter(
                 'main_table.is_active',
                 '1'
             );
-        return $collection;
     }
 
     /**
-     * @return int|void
+     * Get sync abandoned cart
+     *
+     * @return int
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getSyncAbandonedCart()
     {
-        $sync = $this->getAbandonedCartCollection()->addFieldToFilter(
+        $collection = $this->getAbandonedCartCollection()->addFieldToFilter(
             self::AC_SYNC_STATUS,
             [
                 ['eq' => CronConfig::SYNCED]
             ]
         );
-        return count($sync);
+
+        return $collection->getSize();
     }
 
     /**
-     * @return int|void
+     * Get total abandoned cart
+     *
+     * @return int
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getTotalAbandonedCart()
     {
-        $total = $this->getAbandonedCartCollection()->addFieldToFilter(
+        $collection = $this->getAbandonedCartCollection()->addFieldToFilter(
             self::AC_SYNC_STATUS,
             [
                 ['eq' => CronConfig::SYNCED],
                 ['eq' => CronConfig::NOT_SYNCED],
-                ['eq' => CronConfig::FAIL_SYNCED],
+                ['eq' => CronConfig::FAIL_SYNCED]
             ]
         );
-        return count($total);
+
+        return $collection->getSize();
     }
 
     /**
-     * @return int|void
+     * Get not sync abandoned cart
+     *
+     * @return int
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getNotSyncAbandonedCart()
     {
-        $notSync = $this->getAbandonedCartCollection()->addFieldToFilter(
+        $collection = $this->getAbandonedCartCollection()->addFieldToFilter(
             self::AC_SYNC_STATUS,
             [
-                ['eq' => CronConfig::NOT_SYNCED],
+                ['eq' => CronConfig::NOT_SYNCED]
             ]
-        )->getData();
-        return count($notSync);
+        );
+
+        return $collection->getSize();
     }
 
     /**
-     * @return int|void
+     * Get failed sync
+     *
+     * @return int
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getFailedSync()
     {
-        $failSync = $this->getAbandonedCartCollection()->addFieldToFilter(
+        $collection = $this->getAbandonedCartCollection()->addFieldToFilter(
             self::AC_SYNC_STATUS,
             [
-                ['eq' => CronConfig::FAIL_SYNCED],
+                ['eq' => CronConfig::FAIL_SYNCED]
             ]
         );
-        return count($failSync);
+
+        return $collection->getSize();
     }
 }

--- a/Core/Block/Adminhtml/System/Config/ConnectActiveCampaign.php
+++ b/Core/Block/Adminhtml/System/Config/ConnectActiveCampaign.php
@@ -1,17 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ActiveCampaign\Core\Block\Adminhtml\System\Config;
 
-use ActiveCampaign\Core\Helper\Data as ActiveCampaignHelper;
-use Magento\Store\Model\ScopeInterface;
+namespace ActiveCampaign\Core\Block\Adminhtml\System\Config;
 
 class ConnectActiveCampaign extends \Magento\Config\Block\System\Config\Form\Field
 {
     /**
      * Set template to itself
      *
-     * @return $this
-     * @since 100.1.0
+     * @return ConnectActiveCampaign
      */
     protected function _prepareLayout()
     {
@@ -24,13 +21,14 @@ class ConnectActiveCampaign extends \Magento\Config\Block\System\Config\Form\Fie
      * Unset some non-related element parameters
      *
      * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
+     *
      * @return string
-     * @since 100.1.0
      */
     public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
         $element = clone $element;
         $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+
         return parent::render($element);
     }
 
@@ -38,8 +36,8 @@ class ConnectActiveCampaign extends \Magento\Config\Block\System\Config\Form\Fie
      * Get the button and scripts contents
      *
      * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
+     *
      * @return string
-     * @since 100.1.0
      */
     protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
@@ -48,19 +46,21 @@ class ConnectActiveCampaign extends \Magento\Config\Block\System\Config\Form\Fie
         $ajaxUrl = $this->_urlBuilder->getUrl('activecampaign/system_config/connect');
         $connection = true;
         $isConnected = $this->isConnected();
+
         if ($isConnected) {
             $currentButton = $this->escapeHtmlAttr(__('Disconnect'));
             $successButton = $this->escapeHtmlAttr(__('Connect'));
             $ajaxUrl = $this->_urlBuilder->getUrl('activecampaign/system_config/disconnect');
             $connection = false;
         }
+
         $this->addData(
             [
-                'button_label' => __($currentButton),
-                'html_id' => $element->getHtmlId(),
-                'ajax_url' => $ajaxUrl,
-                'connection' => $connection,
-                'success_text' => $successButton,
+                'button_label'  => __($currentButton),
+                'html_id'       => $element->getHtmlId(),
+                'ajax_url'      => $ajaxUrl,
+                'connection'    => $connection,
+                'success_text'  => $successButton,
                 'field_mapping' => str_replace('"', '\\"', json_encode($this->_getFieldMapping()))
             ]
         );
@@ -72,83 +72,90 @@ class ConnectActiveCampaign extends \Magento\Config\Block\System\Config\Form\Fie
      * Returns configuration fields required to perform the ping request
      *
      * @return array
-     * @since 100.1.0
      */
     protected function _getFieldMapping()
     {
         return [
-            'status' => 'active_campaign_general_status',
-            'api_url' => 'active_campaign_general_api_url',
-            'api_key' => 'active_campaign_general_api_key',
-            'store' => 'store_switcher'
+            'status'    => 'active_campaign_general_status',
+            'api_url'   => 'active_campaign_general_api_url',
+            'api_key'   => 'active_campaign_general_api_key',
+            'store'     => 'store_switcher'
         ];
     }
 
     /**
+     * Get connected stores
+     *
      * @return array
      */
-    public function getConnectedStores()
+    public function getConnectedStores(): array
     {
-        $retuen = [];
-        $stores = $this->_storeManager->getStores();
-        foreach ($stores as $store) {
+        $result = [];
+
+        foreach ($this->_storeManager->getStores() as $store) {
             $connectionId = $this->_scopeConfig->getValue(
-                ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                ScopeInterface::SCOPE_STORES,
+                \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                 $store->getId()
             );
 
-            $retuen[$store->getId()]['name'] = $store->getName();
-            $retuen[$store->getId()]['status'] = $connectionId;
+            $result[$store->getId()]['name'] = $store->getName();
+            $result[$store->getId()]['status'] = $connectionId;
         }
 
-        return $retuen;
+        return $result;
     }
 
     /**
+     * Is default config
+     *
      * @return bool
      */
-    public function isDefaultConfig()
+    public function isDefaultConfig(): bool
     {
-        $store = $this->getRequest()->getParam('store');
-        return ($store) ? false : true;
+        return !$this->getRequest()->getParam('store');
     }
 
     /**
+     * Is connected
+     *
      * @return bool
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
-        $store = $this->getRequest()->getParam('store');
-        if ($store) {
+        if ($store = $this->getRequest()->getParam('store')) {
             $connectionId = $this->_scopeConfig->getValue(
-                ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                ScopeInterface::SCOPE_STORES,
+                \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                 $store
             );
 
-            return ($connectionId) ? true : false;
-        } else {
-            $stores = $this->_storeManager->getStores();
-            foreach ($stores as $store) {
-                $connectionId = $this->_scopeConfig->getValue(
-                    ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                    ScopeInterface::SCOPE_STORES,
-                    $store->getId()
-                );
-                if (!$connectionId) {
-                    return false;
-                }
-            }
-
-            return true;
+            return (bool)$connectionId;
         }
+
+        $stores = $this->_storeManager->getStores();
+
+        foreach ($stores as $store) {
+            $connectionId = $this->_scopeConfig->getValue(
+                \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+                $store->getId()
+            );
+
+            if (!$connectionId) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
+     * Get cache URL
+     *
      * @return string
      */
-    public function getCacheUrl()
+    public function getCacheUrl(): string
     {
         return $this->_urlBuilder->getUrl('adminhtml/cache');
     }

--- a/Core/Block/Adminhtml/System/Config/FieldDisable.php
+++ b/Core/Block/Adminhtml/System/Config/FieldDisable.php
@@ -1,52 +1,53 @@
 <?php
+declare(strict_types=1);
+
 namespace ActiveCampaign\Core\Block\Adminhtml\System\Config;
 
-use ActiveCampaign\Core\Helper\Data as ActiveCampaignHelper;
-use Magento\Config\Block\System\Config\Form\Field;
-use Magento\Framework\Data\Form\Element\AbstractElement;
-use Magento\Store\Model\ScopeInterface;
-
-class FieldDisable extends Field
+class FieldDisable extends \Magento\Config\Block\System\Config\Form\Field
 {
     /**
-     * @param AbstractElement $element
-     * @return string
+     * @inheritdoc
      */
-    protected function _getElementHtml(AbstractElement $element)
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
-        if($this->isConnected()) {
+        if ($this->isConnected()) {
             $element->setDisabled('disabled');
         }
+
         return $element->getElementHtml();
     }
 
     /**
+     * Is connected
+     *
      * @return bool
      */
-    public function isConnected()
+    public function isConnected(): bool
     {
-        $store = $this->getRequest()->getParam('store');
-        if ($store) {
+        if ($store = $this->getRequest()->getParam('store')) {
             $connectionId = $this->_scopeConfig->getValue(
-                ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                ScopeInterface::SCOPE_STORES,
+                \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                 $store
             );
 
-            return ($connectionId) ? true : false;
-        } else {
-            $stores = $this->_storeManager->getStores();
-            foreach ($stores as $store) {
-                $connectionId = $this->_scopeConfig->getValue(
-                    ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                    ScopeInterface::SCOPE_STORES,
-                    $store->getId()
-                );
-                if (!$connectionId) {
-                    return false;
-                }
-            }
-            return true;
+            return (bool)$connectionId;
         }
+
+        $stores = $this->_storeManager->getStores();
+
+        foreach ($stores as $store) {
+            $connectionId = $this->_scopeConfig->getValue(
+                \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+                $store->getId()
+            );
+
+            if (!$connectionId) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Core/Controller/Adminhtml/System/Config/Disconnect.php
+++ b/Core/Controller/Adminhtml/System/Config/Disconnect.php
@@ -1,87 +1,77 @@
 <?php
+declare(strict_types=1);
+
 namespace ActiveCampaign\Core\Controller\Adminhtml\System\Config;
 
-use ActiveCampaign\Core\Helper\Curl;
-use ActiveCampaign\Core\Helper\Data as ActiveCampaignHelper;
-use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
-use Magento\Framework\App\Cache\Type\Config;
-use Magento\Framework\App\Cache\TypeListInterface;
-use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
-use Magento\Framework\Controller\Result\JsonFactory;
-use Magento\PageCache\Model\Cache\Type;
-use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\Store\Model\ScopeInterface;
-use Magento\Store\Model\StoreManagerInterface;
-
-class Disconnect extends Action
+class Disconnect extends \Magento\Backend\App\Action
 {
-    const URL_ENDPOINT = "connections";
-    const METHOD = "DELETE";
-    const GET_METHOD = "GET";
+    public const URL_ENDPOINT = 'connections';
+    public const METHOD = 'DELETE';
+    public const GET_METHOD = 'GET';
 
     /**
      * Authorization level of a basic admin session.
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'ActiveCampaign_Core::config_active_campaign';
+    public const ADMIN_RESOURCE = 'ActiveCampaign_Core::config_active_campaign';
 
     /**
-     * @var JsonFactory
+     * @var \Magento\Framework\Controller\Result\JsonFactory
      */
     private $resultJsonFactory;
 
     /**
-     * @var TypeListInterface
+     * @var \Magento\Framework\App\Cache\TypeListInterface
      */
     private $cacheTypeList;
 
     /**
-     * @var ConfigInterface
+     * @var \Magento\Framework\App\Config\ConfigResource\ConfigInterface
      */
     private $configInterface;
 
     /**
-     * @var StoreRepositoryInterface
+     * @var \Magento\Store\Api\StoreRepositoryInterface
      */
     private $storeRepository;
 
     /**
-     * @var ActiveCampaignHelper
+     * @var \ActiveCampaign\Core\Helper\Data
      */
     private $activeCampaignHelper;
 
     /**
-     * @var Curl
+     * @var \ActiveCampaign\Core\Helper\Curl
      */
     private $curl;
 
     /**
-     * @var StoreManagerInterface
+     * @var \Magento\Store\Model\StoreManagerInterface
      */
     private $storeManager;
 
     /**
-     * Connection constructor.
-     * @param Context $context
-     * @param JsonFactory $resultJsonFactory
-     * @param TypeListInterface $cacheTypeList
-     * @param ConfigInterface $configInterface
-     * @param StoreRepositoryInterface $storeRepository
-     * @param StoreManagerInterface $storeManager
-     * @param ActiveCampaignHelper $activeCampaignHelper
-     * @param Curl $curl
+     * Construct
+     *
+     * @param \Magento\Backend\App\Action\Context $context
+     * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList
+     * @param \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface
+     * @param \Magento\Store\Api\StoreRepositoryInterface $storeRepository
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \ActiveCampaign\Core\Helper\Data $activeCampaignHelper
+     * @param \ActiveCampaign\Core\Helper\Curl $curl
      */
     public function __construct(
-        Context $context,
-        JsonFactory $resultJsonFactory,
-        TypeListInterface $cacheTypeList,
-        ConfigInterface $configInterface,
-        StoreRepositoryInterface $storeRepository,
-        StoreManagerInterface $storeManager,
-        ActiveCampaignHelper $activeCampaignHelper,
-        Curl $curl
+        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
+        \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface,
+        \Magento\Store\Api\StoreRepositoryInterface $storeRepository,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \ActiveCampaign\Core\Helper\Data $activeCampaignHelper,
+        \ActiveCampaign\Core\Helper\Curl $curl
     ) {
         parent::__construct($context);
         $this->resultJsonFactory = $resultJsonFactory;
@@ -97,6 +87,7 @@ class Disconnect extends Action
      * Check for connection to server
      *
      * @return \Magento\Framework\Controller\Result\Json
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function execute()
     {
@@ -108,33 +99,39 @@ class Disconnect extends Action
         $return = [];
         $return['success'] = false;
 
-        if ($request['status'] && !empty($request['api_url']) && !empty($request['api_key'])) {
+        if ($request['status']
+            && !empty($request['api_url'])
+            && !empty($request['api_key'])
+        ) {
             try {
                 if ((int)$request['store']) {
                     $connectionId = $this->activeCampaignHelper->getConnectionId($request['store']);
-                    $urlEndpoint = self::URL_ENDPOINT . "/" . $connectionId;
+                    $urlEndpoint = self::URL_ENDPOINT . '/' . $connectionId;
                     $result = $this->curl->deleteConnection(self::METHOD, $urlEndpoint);
+
                     if ($result['success']) {
                         $this->configInterface->deleteConfig(
-                            ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                            ScopeInterface::SCOPE_STORES,
+                            \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                             $request['store']
                         );
                     } else {
                         $return['success'] = false;
                         $return['errorMessage'] = $result['message'];
                     }
-                } elseif ($request['store'] == "0") {
+                } elseif ($request['store'] == '0') {
                     $stores = $this->storeRepository->getList();
+
                     foreach ($stores as $store) {
                         if ($store->getId()) {
-                            $connectionId = $this->activeCampaignHelper->getConnectionId($store->getId());
-                            $urlEndpoint = self::URL_ENDPOINT . "/" . $connectionId;
+                            $connectionId = $this->activeCampaignHelper->getConnectionId((int)$store->getId());
+                            $urlEndpoint = self::URL_ENDPOINT . '/' . $connectionId;
                             $result = $this->curl->deleteConnection(self::METHOD, $urlEndpoint);
+
                             if ($result['success']) {
                                 $this->configInterface->deleteConfig(
-                                    ActiveCampaignHelper::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                                    ScopeInterface::SCOPE_STORES,
+                                    \ActiveCampaign\Core\Helper\Data::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
+                                    \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                                     $store->getId()
                                 );
                             } else {
@@ -145,7 +142,10 @@ class Disconnect extends Action
                     }
                 }
 
-                $allConnections = $this->curl->getAllConnections(self::GET_METHOD, self::URL_ENDPOINT);
+                $allConnections = $this->curl->getAllConnections(
+                    self::GET_METHOD,
+                    self::URL_ENDPOINT
+                );
                 $checkConnections = $this->activeCampaignHelper->checkConnections($allConnections);
                 $return['success'] = $checkConnections;
             } catch (\Exception $e) {
@@ -156,12 +156,13 @@ class Disconnect extends Action
 
         if ($return['success'] === true) {
             $this->cacheTypeList->invalidate([
-                Config::TYPE_IDENTIFIER,
-                Type::TYPE_IDENTIFIER
+                \Magento\Framework\App\Cache\Type\Config::TYPE_IDENTIFIER,
+                \Magento\PageCache\Model\Cache\Type::TYPE_IDENTIFIER
             ]);
         }
 
         $resultJson = $this->resultJsonFactory->create();
+
         return $resultJson->setData($return);
     }
 }

--- a/Core/Helper/Curl.php
+++ b/Core/Helper/Curl.php
@@ -1,85 +1,83 @@
 <?php
+declare(strict_types=1);
 
 namespace ActiveCampaign\Core\Helper;
 
-use ActiveCampaign\Core\Helper\Data as ActiveCampaignHelper;
-use ActiveCampaign\Core\Logger\Logger;
-use ActiveCampaign\SyncLog\Model\SyncLog;
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\RequestOptions;
-use Magento\Framework\App\Helper\AbstractHelper;
-use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Json\Helper\Data as JsonHelper;
-use Magento\Framework\Phrase;
-
-class Curl extends AbstractHelper
+class Curl extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    public const API_VERSION = "/api/3/";
-    public const HTTP_VERSION = "1.1";
-    public const CONTENT_TYPE = "application/json";
+    public const API_VERSION = '/api/3/';
+    public const HTTP_VERSION = '1.1';
+    public const CONTENT_TYPE = 'application/json';
 
     /**
-     * @var Client|ClientInterface
+     * @var \GuzzleHttp\ClientInterface
      */
     private $client;
 
     /**
-     * @var JsonHelper
+     * @var \Magento\Framework\Serialize\Serializer\Json
      */
     private $jsonHelper;
 
     /**
-     * @var Logger
+     * @var \ActiveCampaign\Core\Logger\Logger
      */
     private $logger;
 
     /**
-     * @var ActiveCampaignHelper
+     * @var \ActiveCampaign\Core\Helper\Data
      */
     private $activeCampaignHelper;
 
     /**
-     * @var SyncLog
+     * @var \ActiveCampaign\SyncLog\Model\SyncLog
      */
     private $syncLog;
 
     /**
-     * Curl constructor.
-     * @param Context $context
-     * @param ClientInterface|null $client
-     * @param JsonHelper $jsonHelper
-     * @param Logger $logger
-     * @param Data $activeCampaignHelper
-     * @param SyncLog $syncLog
+     * Construct
+     *
+     * @param \Magento\Framework\App\Helper\Context $context
+     * @param \Magento\Framework\Serialize\Serializer\Json $jsonHelper
+     * @param \ActiveCampaign\Core\Logger\Logger $logger
+     * @param \ActiveCampaign\Core\Helper\Data $activeCampaignHelper
+     * @param \ActiveCampaign\SyncLog\Model\SyncLog $syncLog
+     * @param \GuzzleHttp\ClientInterface|null $client
      */
     public function __construct(
-        Context              $context,
-        ClientInterface      $client = null,
-        JsonHelper           $jsonHelper,
-        Logger               $logger,
-        ActiveCampaignHelper $activeCampaignHelper,
-        SyncLog              $syncLog
-    )
-    {
-        $this->client = $client ?: new Client();
+        \Magento\Framework\App\Helper\Context $context,
+        \Magento\Framework\Serialize\Serializer\Json $jsonHelper,
+        \ActiveCampaign\Core\Logger\Logger $logger,
+        \ActiveCampaign\Core\Helper\Data $activeCampaignHelper,
+        \ActiveCampaign\SyncLog\Model\SyncLog $syncLog,
+        \GuzzleHttp\ClientInterface $client = null
+    ) {
+        $this->client = $client ?: new \GuzzleHttp\Client();
         $this->jsonHelper = $jsonHelper;
         $this->logger = $logger;
         $this->activeCampaignHelper = $activeCampaignHelper;
         $this->syncLog = $syncLog;
+
         parent::__construct($context);
     }
 
     /**
-     * @param $method
-     * @param $urlEndpoint
-     * @param $request
+     * Create connection
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param array $request
      * @param array $data
+     *
      * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function createConnection($method, $urlEndpoint, $request, $data = [])
-    {
+    public function createConnection(
+        string $method,
+        string $urlEndpoint,
+        array $request,
+        array $data = []
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiUrl = empty($apiUrl) ? $request['api_url'] : $apiUrl;
 
@@ -87,98 +85,146 @@ class Curl extends AbstractHelper
         $apiKey = empty($apiKey) ? $request['api_key'] : $apiKey;
 
         $url = $apiUrl . self::API_VERSION . $urlEndpoint;
-        $bodyData = (!empty($data)) ? $this->jsonHelper->jsonEncode($data) : '';
+        $bodyData = (!empty($data)) ? $this->jsonHelper->serialize($data) : '';
         $headers = $this->getHeaders($apiKey);
 
-        $result = $this->sendRequest($urlEndpoint, $method, $url, $headers, $bodyData);
-        return $result;
-    }
-
-    /**
-     * @param $method
-     * @param $urlEndpoint
-     * @param array $data
-     * @return array
-     * @throws GuzzleException
-     */
-    public function orderDataSend($method, $urlEndpoint, array $data = []): array
-    {
-        $apiUrl = $this->activeCampaignHelper->getApiUrl();
-        $apiKey = $this->activeCampaignHelper->getApiKey();
-        $url = $apiUrl . self::API_VERSION . $urlEndpoint;
-        $bodyData = (!empty($data)) ? $this->jsonHelper->jsonEncode($data) : '';
-        $headers = $this->getHeaders($apiKey);
         return $this->sendRequest($urlEndpoint, $method, $url, $headers, $bodyData);
     }
 
     /**
-     * @param $method
-     * @param $urlEndpoint
+     * Send order data
+     *
+     * @param string $method
+     * @param string $urlEndpoint
      * @param array $data
+     *
      * @return array
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function orderDataUpdate($method, $urlEndpoint, array $data = []): array
-    {
+    public function orderDataSend(
+        string $method,
+        string $urlEndpoint,
+        array $data = []
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiKey = $this->activeCampaignHelper->getApiKey();
+
         $url = $apiUrl . self::API_VERSION . $urlEndpoint;
-        $bodyData = (!empty($data)) ? $this->jsonHelper->jsonEncode($data) : '';
+        $bodyData = (!empty($data)) ? $this->jsonHelper->serialize($data) : '';
         $headers = $this->getHeaders($apiKey);
+
         return $this->sendRequest($urlEndpoint, $method, $url, $headers, $bodyData);
     }
 
     /**
-     * @param $method
-     * @param $urlEndpoint
-     * @param $orderId
+     * Update order data
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param array $data
+     *
      * @return array
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function orderDataDelete($method, $urlEndpoint, $orderId): array
-    {
+    public function orderDataUpdate(
+        string $method,
+        string $urlEndpoint,
+        array $data = []
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiKey = $this->activeCampaignHelper->getApiKey();
+
+        $url = $apiUrl . self::API_VERSION . $urlEndpoint;
+        $bodyData = (!empty($data)) ? $this->jsonHelper->serialize($data) : '';
+        $headers = $this->getHeaders($apiKey);
+
+        return $this->sendRequest($urlEndpoint, $method, $url, $headers, $bodyData);
+    }
+
+    /**
+     * Delete order data
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param int|string $orderId
+     *
+     * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function orderDataDelete(
+        string $method,
+        string $urlEndpoint,
+        int|string $orderId
+    ): array {
+        $apiUrl = $this->activeCampaignHelper->getApiUrl();
+        $apiKey = $this->activeCampaignHelper->getApiKey();
+
         $url = $apiUrl . self::API_VERSION . $urlEndpoint . $orderId;
         $headers = $this->getHeaders($apiKey);
+
         return $this->sendRequest($urlEndpoint, $method, $url, $headers);
     }
 
     /**
-     * @param $method
-     * @param $urlEndpoint
+     * Delete connection
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     *
      * @return array
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function deleteConnection($method, $urlEndpoint): array
-    {
+    public function deleteConnection(
+        string $method,
+        string $urlEndpoint
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiKey = $this->activeCampaignHelper->getApiKey();
+
         $url = $apiUrl . self::API_VERSION . $urlEndpoint;
         $headers = $this->getHeaders($apiKey);
+
         return $this->sendRequest($urlEndpoint, $method, $url, $headers);
     }
 
     /**
-     * @throws GuzzleException
+     * Create contacts
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param array $data
+     *
+     * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function createContacts($method, $urlEndpoint, $data = []): array
-    {
+    public function createContacts(
+        string $method,
+        string $urlEndpoint,
+        array $data = []
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiKey = $this->activeCampaignHelper->getApiKey();
 
         $url = $apiUrl . self::API_VERSION . $urlEndpoint;
-        $bodyData = (!empty($data)) ? $this->jsonHelper->jsonEncode($data) : '';
+        $bodyData = (!empty($data)) ? $this->jsonHelper->serialize($data) : '';
         $headers = $this->getHeaders($apiKey);
 
         return $this->sendRequest($urlEndpoint, $method, $url, $headers, $bodyData);
     }
 
     /**
-     * @throws GuzzleException
+     * Get all connections
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     *
+     * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function getAllConnections($method, $urlEndpoint): array
-    {
+    public function getAllConnections(
+        string $method,
+        string $urlEndpoint
+    ): array {
         $apiUrl = $this->activeCampaignHelper->getApiUrl();
         $apiKey = $this->activeCampaignHelper->getApiKey();
 
@@ -189,57 +235,127 @@ class Curl extends AbstractHelper
     }
 
     /**
-     * @param $apiKey
+     * Send request for abandoned cart
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param array $data
+     *
      * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function getHeaders($apiKey): array
-    {
-        $headers = [];
-        $headers['Content-Type'] = self::CONTENT_TYPE;
-        $headers['Api-Token'] = $apiKey;
-        return $headers;
+    public function sendRequestAbandonedCart(
+        string $method,
+        string $urlEndpoint,
+        array $data = []
+    ): array {
+        $apiUrl = $this->activeCampaignHelper->getApiUrl();
+        $apiKey = $this->activeCampaignHelper->getApiKey();
+
+        $url = $apiUrl . self::API_VERSION . $urlEndpoint;
+        $bodyData = (!empty($data)) ? $this->jsonHelper->serialize($data) : '';
+        $headers = $this->getHeaders($apiKey);
+
+        return $this->sendRequest('ecomAbandonedCarts', $method, $url, $headers, $bodyData);
     }
 
     /**
-     * @param $urlEndpoint
-     * @param $method
-     * @param $url
-     * @param $headers
-     * @param string $bodyData
+     * List all customers
+     *
+     * @param string $method
+     * @param string $urlEndpoint
+     * @param string $customerEmail
+     *
      * @return array
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function sendRequest($urlEndpoint, $method, $url, $headers, string $bodyData = ''): array
+    public function listAllCustomers(
+        string $method,
+        string $urlEndpoint,
+        string $customerEmail
+    ): array {
+        $apiUrl = $this->activeCampaignHelper->getApiUrl();
+        $apiKey = $this->activeCampaignHelper->getApiKey();
+
+        $url = $apiUrl . self::API_VERSION . $urlEndpoint . '?filters[email]=' . urlencode($customerEmail);
+        $headers = $this->getHeaders($apiKey);
+
+        return $this->sendRequest('ecomCustomers', $method, $url, $headers);
+    }
+
+    /**
+     * Get headers
+     *
+     * @param string|null $apiKey
+     *
+     * @return array
+     */
+    private function getHeaders(?string $apiKey): array
     {
+        return [
+            'Content-Type'  => self::CONTENT_TYPE,
+            'Api-Token'     => $apiKey
+        ];
+    }
+
+    /**
+     * Send request
+     *
+     * @param string $urlEndpoint
+     * @param string $method
+     * @param string $url
+     * @param array $headers
+     * @param string $bodyData
+     *
+     * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    private function sendRequest(
+        string $urlEndpoint,
+        string $method,
+        string $url,
+        array $headers,
+        string $bodyData = ''
+    ): array {
         $result = [];
         $synclog = $this->syncLog;
+
         try {
             $request = [
-                "METHOD" => $method,
-                "URL" => $url,
-                "HTTP VERSION" => self::HTTP_VERSION,
-                "HEADERS" => $headers,
-                "BODY DATA" => $bodyData
+                'METHOD'        => $method,
+                'URL'           => $url,
+                'HTTP VERSION'  => self::HTTP_VERSION,
+                'HEADERS'       => $headers,
+                'BODY DATA'     => $bodyData
             ];
+
+            /**
+             * @todo Create data interfaces to maintain integrity of data
+             */
             $synclog->setType($urlEndpoint);
             $synclog->setEndpoint($urlEndpoint);
             $synclog->setMethod($method);
-            $synclog->setRequest($this->jsonHelper->jsonEncode($request));
-            $this->logger->info("REQUEST", $request);
+            $synclog->setRequest($this->jsonHelper->serialize($request));
+
+            $this->logger->info('REQUEST', $request);
 
             $options = [];
-            $options[RequestOptions::HEADERS] = $headers;
+            $options[\GuzzleHttp\RequestOptions::HEADERS] = $headers;
+
             if ($bodyData !== null) {
-                $options[RequestOptions::BODY] = $bodyData;
+                $options[\GuzzleHttp\RequestOptions::BODY] = $bodyData;
             }
 
             $resultCurl = $this->client->request($method, $url, $options);
 
             $body = $resultCurl->getBody()->getContents();
-            $response = $this->jsonHelper->jsonDecode($body);
-            $this->logger->info("RESPONSE", $response);
+            $response = $this->jsonHelper->unserialize($body);
+
+            $this->logger->info('RESPONSE', $response);
+
             $synclog->setResponse($body);
             $synclog->setStatus(1);
+
             if (!empty($resultCurl)) {
                 $result['status'] = $resultCurl->getStatusCode();
                 if (isset($result['status']) && array_key_exists($result['status'], $this->successCodes())) {
@@ -260,84 +376,68 @@ class Curl extends AbstractHelper
         } catch (\Exception $e) {
             $synclog->setStatus(0);
             $synclog->setErrors($e->getMessage());
-            $this->logger->critical("MODULE Core" . $e);
+
+            $this->logger->critical('MODULE Core: ' . $e->getMessage());
+
             $result['success'] = false;
             $result['message'] = $e->getMessage();
         }
+
+        /**
+         * @todo Replace with repository service contract
+         */
         $synclog->save();
         $synclog->unsetData();
+
         return $result;
     }
 
     /**
-     * @return string[]
+     * Success codes
+     *
+     * @return array
      */
     private function successCodes(): array
     {
         return [
-            200 => "OK",
-            201 => "Created"
+            200 => 'OK',
+            201 => 'Created'
         ];
     }
 
     /**
-     * @return string[]
+     * Failure codes
+     *
+     * @return array
      */
     private function failureCodes(): array
     {
         return [
-            400 => "Bad Request",
-            404 => "Not Found",
-            422 => "Unprocessable Entity"
+            400 => 'Bad Request',
+            404 => 'Not Found',
+            422 => 'Unprocessable Entity'
         ];
     }
 
     /**
-     * @param $response
-     * @return Phrase
+     * Get message
+     *
+     * @param mixed $response
+     *
+     * @return \Magento\Framework\Phrase|string
      */
-    private function getMessage($response): Phrase
+    private function getMessage(mixed $response): \Magento\Framework\Phrase|string
     {
-        if (isset($response['message'])) {
-            return $response['message'];
-        } elseif (isset($response['error']['title'])) {
-            return $response['error']['title'];
-        } elseif (isset($response['errors']['0']['title'])) {
-            return $response['errors']['0']['title'];
+        if (is_array($response)) {
+            if (isset($response['message'])) {
+                return $response['message'];
+            } elseif (isset($response['error']['title'])) {
+                return $response['error']['title'];
+            } elseif (isset($response['errors']['0']['title'])) {
+                return $response['errors']['0']['title'];
+            }
         }
 
-        return __("Something was wrong Please try again later");
-    }
-
-    /**
-     * @throws GuzzleException
-     */
-    public function sendRequestAbandonedCart($method, $urlEndpoint, $data = []): array
-    {
-        $apiUrl = $this->activeCampaignHelper->getApiUrl();
-        $apiKey = $this->activeCampaignHelper->getApiKey();
-
-        $url = $apiUrl . self::API_VERSION . $urlEndpoint;
-
-        $bodyData = (!empty($data)) ? $this->jsonHelper->jsonEncode($data) : '';
-
-        $headers = $this->getHeaders($apiKey);
-        $type = 'ecomAbandonedCarts';
-        return $this->sendRequest($type, $method, $url, $headers, $bodyData);
-    }
-
-    /**
-     * @throws GuzzleException
-     */
-    public function listAllCustomers($method, $urlEndpoint, $customerEmail): array
-    {
-        $apiUrl = $this->activeCampaignHelper->getApiUrl();
-        $apiKey = $this->activeCampaignHelper->getApiKey();
-
-        $url = $apiUrl . self::API_VERSION . $urlEndpoint . '?filters[email]=' . urlencode($customerEmail);
-
-        $headers = $this->getHeaders($apiKey);
-        $type = 'ecomCustomers';
-        return $this->sendRequest($type, $method, $url, $headers);
+        return __('An unknown error occurred. Please try again later');
     }
 }

--- a/Core/Helper/Data.php
+++ b/Core/Helper/Data.php
@@ -1,48 +1,43 @@
 <?php
+declare(strict_types=1);
+
 namespace ActiveCampaign\Core\Helper;
 
-use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\Helper\AbstractHelper;
-use Magento\Framework\App\Helper\Context;
-use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\Store\Model\ScopeInterface;
-use Magento\Theme\Block\Html\Header\Logo;
-
-class Data extends AbstractHelper
+class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    const ACTIVE_CAMPAIGN_GENERAL_STATUS = "active_campaign/general/status";
-    const ACTIVE_CAMPAIGN_GENERAL_API_URL = "active_campaign/general/api_url";
-    const ACTIVE_CAMPAIGN_GENERAL_API_KEY = "active_campaign/general/api_key";
-    const ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID = "active_campaign/general/connection_id";
+    public const ACTIVE_CAMPAIGN_GENERAL_STATUS = 'active_campaign/general/status';
+    public const ACTIVE_CAMPAIGN_GENERAL_API_URL = 'active_campaign/general/api_url';
+    public const ACTIVE_CAMPAIGN_GENERAL_API_KEY = 'active_campaign/general/api_key';
+    public const ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID = 'active_campaign/general/connection_id';
 
     /**
-     * @var StoreRepositoryInterface
+     * @var \Magento\Store\Api\StoreRepositoryInterface
      */
     private $storeRepository;
 
     /**
-     * @var ConfigInterface
+     * @var \Magento\Framework\App\Config\ConfigResource\ConfigInterface
      */
     private $configInterface;
 
     /**
-     * @var Logo
+     * @var \Magento\Theme\Block\Html\Header\Logo
      */
     private $logo;
 
     /**
-     * Data constructor.
-     * @param StoreRepositoryInterface $storeRepository
-     * @param ConfigInterface $configInterface
-     * @param Context $context
-     * @param Logo $logo
+     * Construct
+     *
+     * @param \Magento\Store\Api\StoreRepositoryInterface $storeRepository
+     * @param \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface
+     * @param \Magento\Framework\App\Helper\Context $context
+     * @param \Magento\Theme\Block\Html\Header\Logo $logo
      */
     public function __construct(
-        StoreRepositoryInterface $storeRepository,
-        ConfigInterface $configInterface,
-        Context $context,
-        Logo $logo
+        \Magento\Store\Api\StoreRepositoryInterface $storeRepository,
+        \Magento\Framework\App\Config\ConfigResource\ConfigInterface $configInterface,
+        \Magento\Framework\App\Helper\Context $context,
+        \Magento\Theme\Block\Html\Header\Logo $logo
     ) {
         parent::__construct($context);
         $this->storeRepository = $storeRepository;
@@ -51,62 +46,77 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param null $scopeCode
+     * Is enabled
+     *
+     * @param int|string|null $scopeCode
+     *
      * @return bool
      */
-    public function isEnabled($scopeCode = null)
+    public function isEnabled(int|string $scopeCode = null): bool
     {
         return $this->scopeConfig->isSetFlag(
             self::ACTIVE_CAMPAIGN_GENERAL_STATUS,
-            ScopeInterface::SCOPE_STORES,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
             $scopeCode
         );
     }
 
     /**
-     * @param null $scopeCode
-     * @return mixed
+     * Get API URL
+     *
+     * @param int|string|null $scopeCode
+     *
+     * @return string|null
      */
-    public function getApiUrl($scopeCode = null)
+    public function getApiUrl(int|string $scopeCode = null): ?string
     {
         return $this->scopeConfig->getValue(
             self::ACTIVE_CAMPAIGN_GENERAL_API_URL,
-            ScopeInterface::SCOPE_STORES,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
             $scopeCode
         );
     }
 
     /**
-     * @param null $scopeCode
-     * @return mixed
+     * Get API key
+     *
+     * @param int|string|null $scopeCode
+     *
+     * @return string|null
      */
-    public function getApiKey($scopeCode = null)
+    public function getApiKey(int|string $scopeCode = null): ?string
     {
         return $this->scopeConfig->getValue(
             self::ACTIVE_CAMPAIGN_GENERAL_API_KEY,
-            ScopeInterface::SCOPE_STORES,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
             $scopeCode
         );
     }
 
     /**
-     * @param null $scopeCode
-     * @return mixed
+     * Get connection ID
+     *
+     * @param int|string|null $scopeCode
+     *
+     * @return string|null
      */
-    public function getConnectionId($scopeCode = null)
+    public function getConnectionId(int|string $scopeCode = null): ?string
     {
         return $this->scopeConfig->getValue(
             self::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-            ScopeInterface::SCOPE_STORES,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
             $scopeCode
         );
     }
 
     /**
-     * @param null $scopeCode
+     * Get store logo
+     *
+     * @param int|string|null $scopeCode
+     *
      * @return string
      */
-    public function getStoreLogo($scopeCode = null)
+    public function getStoreLogo(int|string $scopeCode = null): string
     {
         $folderName = \Magento\Config\Model\Config\Backend\Image\Logo::UPLOAD_DIR;
         $storeLogoPath = $this->scopeConfig->getValue(
@@ -130,26 +140,32 @@ class Data extends AbstractHelper
      * Converts to cents the price amount
      *
      * @param float|null $price
+     *
      * @return int
      */
-    public function priceToCents($price = 0.0)
+    public function priceToCents(?float $price = 0.0): int
     {
         return (int) (round($price, 2) * 100);
     }
 
     /**
-     * @param $allConnections
+     * Check connections
+     *
+     * @param array $allConnections
+     *
      * @return bool
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function checkConnections($allConnections)
+    public function checkConnections(array $allConnections): bool
     {
         if ($allConnections['success']) {
             $activeConnectionIds = [];
-            foreach ($allConnections['data']['connections'] as  $connection) {
+
+            foreach ($allConnections['data']['connections'] as $connection) {
                 $store = $this->storeRepository->get($connection['externalid']);
                 $connectionId = $this->getConnectionId($store->getId());
                 $activeConnectionIds[] = $connection['id'];
+
                 if ($connectionId != $connection['id']) {
                     $this->saveConfig(
                         self::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
@@ -160,13 +176,14 @@ class Data extends AbstractHelper
             }
 
             $stores = $this->storeRepository->getList();
+
             foreach ($stores as $store) {
                 if ($store->getId()) {
                     $connectionId = $this->getConnectionId($store->getId());
                     if (($connectionId) && (!in_array($connectionId, $activeConnectionIds))) {
                         $this->configInterface->deleteConfig(
                             self::ACTIVE_CAMPAIGN_GENERAL_CONNECTION_ID,
-                            ScopeInterface::SCOPE_STORES,
+                            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
                             $store->getId()
                         );
                     }
@@ -175,17 +192,27 @@ class Data extends AbstractHelper
 
             return true;
         }
+
         return false;
     }
 
     /**
-     * @param $path
-     * @param $value
-     * @param $scopeId
+     * Save config
+     *
+     * @param string $path
+     * @param string $value
+     * @param int $scopeId
+     *
+     * @return void
      */
-    public function saveConfig($path, $value, $scopeId)
-    {
-        $scope = ($scopeId) ? ScopeInterface::SCOPE_STORES : ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
+    public function saveConfig(
+        string $path,
+        string $value,
+        int $scopeId
+    ) {
+        $scope = ($scopeId)
+            ? \Magento\Store\Model\ScopeInterface::SCOPE_STORES
+            : \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
         $this->configInterface->saveConfig($path, $value, $scope, $scopeId);
     }
 }

--- a/Core/Logger/Handler.php
+++ b/Core/Logger/Handler.php
@@ -1,18 +1,20 @@
 <?php
-namespace ActiveCampaign\Core\Logger;
+declare(strict_types=1);
 
-use Monolog\Logger;
+namespace ActiveCampaign\Core\Logger;
 
 class Handler extends \Magento\Framework\Logger\Handler\Base
 {
     /**
      * Logging level
+     *
      * @var int
      */
-    protected $loggerType = Logger::INFO;
+    protected $loggerType = \Monolog\Logger::INFO;
 
     /**
      * File name
+     *
      * @var string
      */
     protected $fileName = '/var/log/activecampaign.log';

--- a/Core/Logger/Logger.php
+++ b/Core/Logger/Logger.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace ActiveCampaign\Core\Logger;
 
 class Logger extends \Monolog\Logger

--- a/Core/etc/adminhtml/system.xml
+++ b/Core/etc/adminhtml/system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="active_campaign" translate="label" sortOrder="1">
+        <tab id="active_campaign" translate="label" sortOrder="10000">
             <label>ActiveCampaign</label>
         </tab>
         <section id="active_campaign" translate="label" type="text" sortOrder="100" showInDefault="1" showInStore="1">

--- a/Customer/Block/Adminhtml/System/Config/CustomerSyncStatus.php
+++ b/Customer/Block/Adminhtml/System/Config/CustomerSyncStatus.php
@@ -1,24 +1,16 @@
 <?php
+declare(strict_types=1);
 
 namespace ActiveCampaign\Customer\Block\Adminhtml\System\Config;
 
-use ActiveCampaign\Customer\Model\Config\CronConfig;
-use Magento\Backend\Block\Template\Context;
-use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerFactory;
-
 class CustomerSyncStatus extends \Magento\Backend\Block\Template
 {
-    const AC_SYNC_STATUS = "ac_sync_status";
+    public const AC_SYNC_STATUS = 'ac_sync_status';
 
     /**
      * @var string
      */
     protected $_template = 'ActiveCampaign_Customer::system/config/customer_sync_status.phtml';
-
-    /**
-     * @var CustomerFactory
-     */
-    protected $customerFactory;
 
     /**
      * @var int
@@ -41,39 +33,152 @@ class CustomerSyncStatus extends \Magento\Backend\Block\Template
     public $failSyncedCustomer = 0;
 
     /**
+     * @var \Magento\Customer\Api\CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * @var \Magento\Framework\Api\SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var \Magento\Framework\Api\FilterBuilder
+     */
+    private $filterBuilder;
+
+    /**
+     * Construct
      *
-     * @param Context $context
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository
+     * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param \Magento\Framework\Api\FilterBuilder $filterBuilder
      * @param array $data
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function __construct(
-        Context $context,
-        CustomerFactory $customerFactory,
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
+        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
+        \Magento\Framework\Api\FilterBuilder $filterBuilder,
         array $data = []
     ) {
-        $this->customerFactory = $customerFactory;
+        $this->customerRepository = $customerRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->filterBuilder = $filterBuilder;
+
         parent::__construct($context, $data);
         $this->setSyncStatusData();
     }
 
     /**
-     * @return $this
+     * Set sync status data
+     *
+     * @return CustomerSyncStatus
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function setSyncStatusData()
     {
-        $customersData = $this->customerFactory->create()
-            ->addAttributeToFilter([
-                ['attribute' => self::AC_SYNC_STATUS,'null' => true ],
-                ['attribute' => self::AC_SYNC_STATUS,'eq' => CronConfig::SYNCED ],
-                ['attribute' => self::AC_SYNC_STATUS,'eq' => CronConfig::NOT_SYNCED ],
-                ['attribute' => self::AC_SYNC_STATUS,'eq' => CronConfig::FAIL_SYNCED ]
-            ])->getData();
-
-        $this->totalCustomer = count($customersData);
-        $this->syncedCustomer = count(array_keys(array_column($customersData, self::AC_SYNC_STATUS), CronConfig::SYNCED));
-        $this->notSyncedCustomer = count(array_keys(array_column($customersData, self::AC_SYNC_STATUS), CronConfig::NOT_SYNCED));
-        $this->failSyncedCustomer = count(array_keys(array_column($customersData, self::AC_SYNC_STATUS), CronConfig::FAIL_SYNCED));
+        $this->totalCustomer = $this->getTotalCustomersCount();
+        $this->syncedCustomer = $this->getSyncedCustomerCount();
+        $this->notSyncedCustomer = $this->getNotSyncedCustomerCount();
+        $this->failSyncedCustomer = $this->getFailSyncedCustomerCount();
 
         return $this;
+    }
+
+    /**
+     * Get customer counter helper
+     *
+     * @param \Magento\Framework\Api\Filter[] $filter
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getCustomerCountHelper(array $filter = []): int
+    {
+        $searchCriteria = $this->searchCriteriaBuilder;
+
+        if (count($filter)) {
+            $searchCriteria->addFilters($filter);
+        }
+
+        $searchCriteria->setCurrentPage(1)
+            ->setPageSize(1);
+
+        return $this->customerRepository
+            ->getList($searchCriteria->create())
+            ->getTotalCount();
+    }
+
+    /**
+     * Get total customers count
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getTotalCustomersCount(): int
+    {
+        return $this->getCustomerCountHelper();
+    }
+
+    /**
+     * Get synced customer count
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function getSyncedCustomerCount(): int
+    {
+        return $this->getCustomerCountHelper([
+            $this->filterBuilder
+                ->setField(self::AC_SYNC_STATUS)
+                ->setValue(\ActiveCampaign\Customer\Model\Config\CronConfig::SYNCED)
+                ->setConditionType('eq')
+                ->create()
+        ]);
+    }
+
+    /**
+     * Get not synced customer count
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function getNotSyncedCustomerCount(): int
+    {
+        return $this->getCustomerCountHelper(
+            [
+                $this->filterBuilder
+                    ->setField(self::AC_SYNC_STATUS)
+                    ->setValue(\ActiveCampaign\Customer\Model\Config\CronConfig::NOT_SYNCED)
+                    ->setConditionType('eq')
+                    ->create(),
+                $this->filterBuilder
+                    ->setField(self::AC_SYNC_STATUS)
+                    ->setValue(true)
+                    ->setConditionType('null')
+                    ->create()
+            ]
+        );
+    }
+
+    /**
+     * Get failed synced customer count
+     *
+     * @return int
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function getFailSyncedCustomerCount(): int
+    {
+        return $this->getCustomerCountHelper([
+            $this->filterBuilder
+                ->setField(self::AC_SYNC_STATUS)
+                ->setValue(\ActiveCampaign\Customer\Model\Config\CronConfig::FAIL_SYNCED)
+                ->setConditionType('eq')
+                ->create()
+        ]);
     }
 }


### PR DESCRIPTION
Fixes performance issues when viewing sync counts in system config. The sorting of the system config always sets always sets this modules config to be loaded and shown first. This causes massive delays when using larger datasets and sometimes prevents the ability to view non-related configs.

The commits include:
- Move module to be shown near the bottom of the system config.
- Update abandoned cart syncs to use total collection counts rather than loading the collection into memory and the performing a count.
- Update customer and order syncs to use the search and filter builder counts rather than loading the collection into memory and the performing a count.