### PR TITLE
Update composer.json to fix syntax error while running composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~7.3.0||~7.4.0||~8.0||~8.1",
+        "php": "~7.3.0||~7.4.0||~8.0||~8.1"
     },
     "replace": {
         "activecampaign/core": "self.version",


### PR DESCRIPTION
Remove extra ","  which causes an syntax error. Fixes #57.

```Downloading https://api.github.com/repos/ActiveCampaign/module-integration/contents/composer.json?ref=5415b6aad775981bd848a742eb801680941e717c
[200] https://api.github.com/repos/ActiveCampaign/module-integration/contents/composer.json?ref=5415b6aad775981bd848a742eb801680941e717c
Skipped branch main, "5415b6aad775981bd848a742eb801680941e717c:composer.json" does not contain valid JSON
Parse error on line 14:
...0||~8.0||~8.1",    },    "replace": {
---------------------^
Expected: 'STRING' - It appears you have an extra trailing comma
```