### PR TITLE
v2.1.31

### DIFF
--- a/Order/Model/OrderData/OrderDataSend.php
+++ b/Order/Model/OrderData/OrderDataSend.php
@@ -1,7 +1,7 @@
 <?php
 namespace ActiveCampaign\Order\Model\OrderData;
 
-use ActiveCampaign\AbandonedCart\Model\Config\CronConfig;
+use ActiveCampaign\Order\Model\Config\CronConfig;
 use ActiveCampaign\Core\Helper\Curl;
 use ActiveCampaign\Core\Helper\Data as ActiveCampaignHelper;
 use ActiveCampaign\Core\Helper\Data as CoreHelper;

--- a/Order/Observer/OrderCancelFlag.php
+++ b/Order/Observer/OrderCancelFlag.php
@@ -1,9 +1,11 @@
 <?php
 namespace ActiveCampaign\Order\Observer;
 
+use ActiveCampaign\Order\Model\Config\CronConfig;
 use ActiveCampaign\Order\Helper\Data as ActiveCampaignOrderHelper;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\Order;
 
 class OrderCancelFlag implements ObserverInterface
 {
@@ -26,15 +28,21 @@ class OrderCancelFlag implements ObserverInterface
             return;
         }
 
-        if ($order->getStatus() !== 'canceled') {
+        $isCanceled = $order->getStatus() === 'canceled'
+            || (method_exists($order, 'getState') && $order->getState() === Order::STATE_CANCELED);
+        if (!$isCanceled) {
             return;
         }
 
-        if ($order->getOrigData('status') === 'canceled') {
-            return;
-        }
+        $currentSyncStatus = (int)$order->getData('ac_order_sync_status');
+        $previousStatus = $order->getOrigData('status');
+        $isNewCancel = $previousStatus === null
+            || $previousStatus !== 'canceled';
+        $needsSync = $currentSyncStatus !== CronConfig::SYNCED;
 
-        $order->setData('ac_order_sync_status', 0);
+        if ($isNewCancel && $needsSync) {
+            $order->setData('ac_order_sync_status', CronConfig::NOT_SYNCED);
+        }
     }
 }
 

--- a/Order/Observer/OrderCancelSync.php
+++ b/Order/Observer/OrderCancelSync.php
@@ -1,10 +1,12 @@
 <?php
 namespace ActiveCampaign\Order\Observer;
 
+use ActiveCampaign\Order\Model\Config\CronConfig;
 use ActiveCampaign\Order\Helper\Data as ActiveCampaignOrderHelper;
 use ActiveCampaign\Order\Model\OrderData\OrderDataSend;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\Order;
 use Psr\Log\LoggerInterface;
 
 class OrderCancelSync implements ObserverInterface
@@ -38,11 +40,19 @@ class OrderCancelSync implements ObserverInterface
             return;
         }
 
-        if ($order->getStatus() !== 'canceled') {
+        $isCanceled = $order->getStatus() === 'canceled'
+            || (method_exists($order, 'getState') && $order->getState() === Order::STATE_CANCELED);
+        if (!$isCanceled) {
             return;
         }
 
-        if ($order->getOrigData('status') === 'canceled') {
+        $currentSyncStatus = (int)$order->getData('ac_order_sync_status');
+        $previousStatus = $order->getOrigData('status');
+        $isNewCancel = $previousStatus === null
+            || $previousStatus !== 'canceled';
+        $needsSync = $currentSyncStatus !== CronConfig::SYNCED;
+
+        if (!$isNewCancel || !$needsSync) {
             return;
         }
 

--- a/Order/composer.json
+++ b/Order/composer.json
@@ -9,7 +9,7 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.1.15",
+    "version": "2.1.16",
     "require": {
         "php": "~7.3.0||~7.4.0||~8.0||~8.1||~8.2||~8.3||~8.4",
         "activecampaign/core": "2.1.*"

--- a/Order/etc/module.xml
+++ b/Order/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="ActiveCampaign_Order" setup_version="2.1.15">
+    <module name="ActiveCampaign_Order" setup_version="2.1.16">
         <sequence>
             <module name="ActiveCampaign_Core" />
             <module name="ActiveCampaign_Customer"/>

--- a/Product/Controller/Adminhtml/Product/Masssync.php
+++ b/Product/Controller/Adminhtml/Product/Masssync.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace ActiveCampaign\Product\Controller\Adminhtml\Product;
+
+use ActiveCampaign\Product\Helper\Data as ProductHelper;
+use ActiveCampaign\Product\Model\CatalogProductProvider;
+use ActiveCampaign\Product\Model\ProductSync;
+use ActiveCampaign\Product\Model\ProductSyncFlagRepository;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Ui\Component\MassAction\Filter;
+
+class Masssync extends Action
+{
+    public const ADMIN_RESOURCE = 'Magento_Catalog::catalog';
+
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var ProductHelper
+     */
+    protected $productHelper;
+
+    /**
+     * @var CatalogProductProvider
+     */
+    protected $catalogProductProvider;
+
+    /**
+     * @var ProductSync
+     */
+    protected $productSync;
+
+    /**
+     * @var ProductSyncFlagRepository
+     */
+    protected $flagRepository;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @var MessageManagerInterface
+     */
+    protected $msgManager;
+
+    /**
+     * Masssync constructor.
+     *
+     * @param Context                    $context
+     * @param Filter                     $filter
+     * @param CollectionFactory          $collectionFactory
+     * @param ProductHelper              $productHelper
+     * @param CatalogProductProvider     $catalogProductProvider
+     * @param ProductSync                $productSync
+     * @param ProductSyncFlagRepository  $flagRepository
+     * @param StoreManagerInterface      $storeManager
+     */
+    public function __construct(
+        Context $context,
+        Filter $filter,
+        CollectionFactory $collectionFactory,
+        ProductHelper $productHelper,
+        CatalogProductProvider $catalogProductProvider,
+        ProductSync $productSync,
+        ProductSyncFlagRepository $flagRepository,
+        StoreManagerInterface $storeManager
+    ) {
+        parent::__construct($context);
+        $this->filter = $filter;
+        $this->collectionFactory = $collectionFactory;
+        $this->productHelper = $productHelper;
+        $this->catalogProductProvider = $catalogProductProvider;
+        $this->productSync = $productSync;
+        $this->flagRepository = $flagRepository;
+        $this->storeManager = $storeManager;
+        $this->msgManager = $context->getMessageManager();
+    }
+
+    public function execute()
+    {
+        $resultRedirect = $this->resultRedirectFactory->create();
+        try {
+            $collection = $this->filter->getCollection($this->collectionFactory->create());
+            $productIds = $collection->getAllIds();
+            $countSelected = count($productIds);
+
+            if ($countSelected === 0) {
+                $this->msgManager->addNoticeMessage(__('No products selected.'));
+                return $resultRedirect->setPath('catalog/product/index');
+            }
+
+            $defaultStore = $this->storeManager->getDefaultStoreView();
+            if (!$defaultStore) {
+                $stores = $this->storeManager->getStores(false, true);
+                $defaultStore = $stores ? reset($stores) : null;
+            }
+            if (!$defaultStore) {
+                $this->msgManager->addErrorMessage(
+                    __('Could not resolve a store view for product sync.')
+                );
+                return $resultRedirect->setPath('catalog/product/index');
+            }
+            $storeId = (int)$defaultStore->getId();
+
+            if (!$this->productHelper->isProductSyncEnabled()) {
+                $this->msgManager->addErrorMessage(
+                    __('ActiveCampaign Product Sync is disabled. Please enable it in configuration.')
+                );
+                return $resultRedirect->setPath('catalog/product/index');
+            }
+
+            $payloads = $this->catalogProductProvider->buildProducts(
+                $storeId,
+                null,
+                $productIds
+            );
+
+            if (empty($payloads)) {
+                $this->msgManager->addErrorMessage(
+                    __('No product payloads could be built for the selected products.')
+                );
+                return $resultRedirect->setPath('catalog/product/index');
+            }
+
+            $this->flagRepository->seedFlagsForStore($storeId, $productIds);
+
+            $result = $this->productSync->bulkUpsertProducts($payloads);
+
+            $countSynced = 0;
+            $syncedIds = [];
+            if (!empty($result['success'])) {
+                $countSynced = count($payloads);
+                $syncedIds = $productIds;
+            }
+
+            if (!empty($syncedIds)) {
+                $this->flagRepository->markSynced($storeId, $syncedIds);
+            }
+
+            $countFailed = $countSelected - $countSynced;
+
+            if ($countSynced > 0) {
+                $this->msgManager->addSuccessMessage(
+                    __('Products synced: %1', $countSynced)
+                );
+            }
+            if ($countFailed > 0) {
+                $msg = __('Products failed to sync: %1', $countFailed);
+                if (!empty($result['message'])) {
+                    $msg .= ' — ' . __($result['message']);
+                }
+                $this->msgManager->addErrorMessage($msg);
+            }
+        } catch (\Throwable $e) {
+            $this->msgManager->addErrorMessage(
+                __('Product sync error: %1', $e->getMessage())
+            );
+        }
+
+        return $resultRedirect->setPath('catalog/product/index');
+    }
+
+    protected function _isAllowed()
+    {
+        return $this->_authorization->isAllowed(self::ADMIN_RESOURCE);
+    }
+}

--- a/Product/Ui/Component/Listing/Column/ProductStatus.php
+++ b/Product/Ui/Component/Listing/Column/ProductStatus.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace ActiveCampaign\Product\Ui\Component\Listing\Column;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class ProductStatus extends Column
+{
+    private const FLAG_TABLE = 'activecampaign_product_sync';
+    private const STATUS_NOT_SYNCED = 0;
+    private const STATUS_SYNCED = 1;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resource;
+
+    /**
+     * @param ContextInterface   $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param ResourceConnection $resource
+     * @param array              $components
+     * @param array              $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        ResourceConnection $resource,
+        array $components = [],
+        array $data = []
+    ) {
+        $this->resource = $resource;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    /**
+     * @param array $dataSource
+     * @return array
+     */
+    public function prepareDataSource(array $dataSource)
+    {
+        if (empty($dataSource['data']['items'])) {
+            return $dataSource;
+        }
+
+        $productIds = [];
+        foreach ($dataSource['data']['items'] as $item) {
+            if (isset($item['entity_id'])) {
+                $productIds[] = (int)$item['entity_id'];
+            }
+        }
+
+        $statusMap = [];
+        if (!empty($productIds)) {
+            $conn = $this->resource->getConnection();
+            $table = $this->resource->getTableName(self::FLAG_TABLE);
+            $select = $conn->select()
+                ->from($table, ['product_id', 'sync_status'])
+                ->where('product_id IN (?)', $productIds);
+            foreach ($conn->fetchAll($select) as $row) {
+                $pid = (int)$row['product_id'];
+                $statusMap[$pid] = (int)$row['sync_status'];
+            }
+        }
+
+        $columnName = $this->getData('name');
+        foreach ($dataSource['data']['items'] as &$item) {
+            if (!isset($item['entity_id'])) {
+                $item[$columnName] = __('Not Synced');
+                continue;
+            }
+            $pid = (int)$item['entity_id'];
+            $status = $statusMap[$pid] ?? self::STATUS_NOT_SYNCED;
+            $item[$columnName] = $status === self::STATUS_SYNCED
+                ? __('Synced')
+                : __('Not Synced');
+        }
+
+        return $dataSource;
+    }
+}

--- a/Product/composer.json
+++ b/Product/composer.json
@@ -9,7 +9,7 @@
     "config": {
         "sort-packages": true
     },
-    "version": "1.0.5",
+    "version": "1.0.6",
     "require": {
         "php": "~7.3.0||~7.4.0||~8.0||~8.1||~8.2||~8.3||~8.4"
     },

--- a/Product/etc/adminhtml/routes.xml
+++ b/Product/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="productmass" frontName="productmass">
+            <module name="ActiveCampaign_Product" />
+        </route>
+    </router>
+</config>

--- a/Product/etc/module.xml
+++ b/Product/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="ActiveCampaign_Product" setup_version="1.0.5">
+    <module name="ActiveCampaign_Product" setup_version="1.0.6">
         <sequence>
             <module name="ActiveCampaign_Core"/>
         </sequence>

--- a/Product/view/adminhtml/ui_component/product_listing.xml
+++ b/Product/view/adminhtml/ui_component/product_listing.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top">
+        <massaction name="listing_massaction">
+            <action name="product_sync">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="type" xsi:type="string">product_sync</item>
+                        <item name="label" xsi:type="string" translate="true">Sync to ActiveCampaign</item>
+                        <item name="url" xsi:type="url" path="productmass/product/masssync"/>
+                        <item name="confirm" xsi:type="array">
+                            <item name="title" xsi:type="string" translate="true">Sync Product(s)</item>
+                            <item name="message" xsi:type="string" translate="true">Are you sure you wan\'t to sync selected items?</item>
+                        </item>
+                    </item>
+                </argument>
+            </action>
+        </massaction>
+    </listingToolbar>
+    <columns name="product_columns">
+        <column name="ac_product_sync_status" class="ActiveCampaign\Product\Ui\Component\Listing\Column\ProductStatus">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="visible" xsi:type="boolean">true</item>
+                    <item name="label" xsi:type="string" translate="true">ActiveCampaign Sync Status</item>
+                    <item name="sortable" xsi:type="boolean">false</item>
+                    <item name="filter" xsi:type="boolean">false</item>
+                </item>
+            </argument>
+        </column>
+    </columns>
+</listing>

--- a/marketplace-composer.json
+++ b/marketplace-composer.json
@@ -2,7 +2,7 @@
   "name": "activecampaign/module-integration",
   "description": "ActiveCampaign extension for Magento 2.3 and 2.4",
   "type": "metapackage",
-  "version": "2.1.30",
+  "version": "2.1.31",
   "license": [
     "OSL-3.0"
   ],


### PR DESCRIPTION
-  Adds "Sync to ActiveCampaign" mass-action on product grid 
- Adds "ActiveCampaign Sync Status" renderer column
- Fixed: Cancelled orders now always sync to ActiveCampaign